### PR TITLE
Remove MAX_MC_VIFS macro

### DIFF
--- a/src/igmpproxy.h
+++ b/src/igmpproxy.h
@@ -68,7 +68,6 @@
 #define MAX_IP_HEADER_LEN	60
 #define IP_HEADER_RAOPT_LEN	24
 
-#define MAX_MC_VIFS    32     // !!! check this const in the specific includes
 #define MAX_UPS_VIFS    8
 
 // Useful macros..
@@ -199,7 +198,7 @@ int isAdressValidForIf(struct IfDesc* intrface, uint32_t ipaddr);
 struct MRouteDesc {
     struct in_addr  OriginAdr, McAdr;
     short           InVif;
-    uint8_t           TtlVc[ MAX_MC_VIFS ];
+    uint8_t         TtlVc[MAXVIFS];
 };
 
 // IGMP socket as interface for the mrouted API

--- a/src/mroute-api.c
+++ b/src/mroute-api.c
@@ -40,11 +40,6 @@
 
 #include "igmpproxy.h"
 
-// MAX_MC_VIFS from mclab.h must have same value as MAXVIFS from mroute.h
-#if MAX_MC_VIFS != MAXVIFS
-# error "constants don't match, correct mclab.h"
-#endif
-
 // need an IGMP socket as interface for the mrouted API
 // - receives the IGMP messages
 int         MRouterFD;          /* socket for all network I/O  */

--- a/src/rttable.c
+++ b/src/rttable.c
@@ -291,9 +291,8 @@ int insertRoute(uint32_t group, int ifx, uint32_t src) {
     }
 
     // Santiycheck the VIF index...
-    //if(ifx < 0 || ifx >= MAX_MC_VIFS) {
-    if(ifx >= MAX_MC_VIFS) {
-        my_log(LOG_WARNING, 0, "The VIF Ix %d is out of range (0-%d). Table insert failed.",ifx,MAX_MC_VIFS);
+    if(ifx >= MAXVIFS) {
+        my_log(LOG_WARNING, 0, "The VIF Ix %d is out of range (0-%d). Table insert failed.", ifx, MAXVIFS-1);
         return 0;
     }
 


### PR DESCRIPTION
Its value is same as MAXVIFS, so use MAXVIFS instead.